### PR TITLE
fix bulk_walk against noSuchInstance identifier

### DIFF
--- a/lib/Mojo/SNMP.pm
+++ b/lib/Mojo/SNMP.pm
@@ -518,7 +518,13 @@ sub _snmp_method_bulk_walk {
   my ($callback, $end, %tree, %types);
 
   $end = sub {
-    $session->pdu->var_bind_list(\%tree, \%types) if %tree;
+    if (scalar keys %tree) {
+      $session->pdu->var_bind_list(\%tree, \%types);
+    }
+    else {
+      $session->pdu->var_bind_list({$base_oid => 'noSuchInstance'},
+                                   {$base_oid => $Net::SNMP::NOSUCHINSTANCE});
+    }
     $session->$last;
     $end = $callback = undef;
   };


### PR DESCRIPTION
Set `var_bind_list` to `noSuchInstance` when no results are returned from the `get_bulk_request`.

If bulk_walk is run against a missing identifier, then the _initial_ `get_bulk_request()` will walk forward in the tree and retrieve values not matching the `oid_base`. However they are already stored in the PDU by `Net::SNMP`, so the code in `$callback` to check `oid_base` never sees them.

This fix will always set/overwrite the `var_bind_list` within PDU, either to the returned and matching identifier-values, or to `noSuchInstance`.
